### PR TITLE
Hide approach implemented

### DIFF
--- a/projects/ng-can/src/lib/directives/can.directive.spec.ts
+++ b/projects/ng-can/src/lib/directives/can.directive.spec.ts
@@ -1,7 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { NgCanDirective } from './can.directive';
-import { Component, DebugElement } from '@angular/core';
+import { Component, DebugElement, ViewChild } from '@angular/core';
+import { MODULE_OPTIONS } from '../module.options';
 
 @Component({
   template: `
@@ -11,16 +12,32 @@ import { Component, DebugElement } from '@angular/core';
   ]
 })
 class SandboxOneComponent {
+  @ViewChild(NgCanDirective) ngCanDirective;
 }
 
 @Component({
   template: `
-    <div id="some-div-2" ng-can [conditions]="{read: true}" [permissions]="{read: true}"></div>`,
+    <div id="some-div-2" ng-can [conditions]="{read: true}" [permissions]="{read: true}"
+         [hideApproach]="'hidden'"></div>`,
   providers: [
     NgCanDirective
   ]
 })
 class SandboxTwoComponent {
+  @ViewChild(NgCanDirective) ngCanDirective;
+}
+
+
+@Component({
+  template: `
+    <div id="some-div-3" ng-can [conditions]="{read: true}" [permissions]="{read: false}"
+         [hideApproach]="'hidden'"></div>`,
+  providers: [
+    NgCanDirective
+  ]
+})
+class SandboxThreeComponent {
+  @ViewChild(NgCanDirective) ngCanDirective;
 }
 
 describe('NgCanDirective', () => {
@@ -28,16 +45,29 @@ describe('NgCanDirective', () => {
   let fixtureOne: ComponentFixture<SandboxOneComponent>;
   let debugElementOne: DebugElement;
 
-  let componentTwo: SandboxOneComponent;
-  let fixtureTwo: ComponentFixture<SandboxOneComponent>;
+  let componentTwo: SandboxTwoComponent;
+  let fixtureTwo: ComponentFixture<SandboxTwoComponent>;
   let debugElementTwo: DebugElement;
+
+  let componentThree: SandboxThreeComponent;
+  let fixtureThree: ComponentFixture<SandboxThreeComponent>;
+  let debugElementThree: DebugElement;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [
         SandboxOneComponent,
         SandboxTwoComponent,
+        SandboxThreeComponent,
         NgCanDirective
+      ],
+      providers: [
+        {
+          provide: MODULE_OPTIONS,
+          useValue: {
+            hide_approach: 'visibility'
+          }
+        },
       ]
     });
 
@@ -49,19 +79,39 @@ describe('NgCanDirective', () => {
     componentTwo = fixtureTwo.componentInstance;
     debugElementTwo = fixtureTwo.debugElement;
 
+    fixtureThree = TestBed.createComponent(SandboxThreeComponent);
+    componentThree = fixtureThree.componentInstance;
+    debugElementThree = fixtureThree.debugElement;
+
     fixtureOne.detectChanges();
     fixtureTwo.detectChanges();
+    fixtureThree.detectChanges();
   });
 
-  it('should hide SandboxOneComponent', () => {
+  it('should hide SandboxOneComponent by permissions/conditions set', () => {
     const node = debugElementOne.nativeElement.querySelector('#some-div');
 
     expect(node.style.visibility).toBe('hidden');
   });
 
-  it('should show SandboxTwoComponent', () => {
+  it('should show SandboxTwoComponent by permissions/conditions set', () => {
     const node = debugElementTwo.nativeElement.querySelector('#some-div-2');
 
     expect(node.style.visibility).not.toBe('hidden');
+  });
+
+  it('should use default Hide Approach set from Module Options, but it can be overwritten by [hideApproach] property', () => {
+    expect(componentOne.ngCanDirective['hideApproach']).toBe('visibility');
+    expect(componentTwo.ngCanDirective['hideApproach']).toBe('hidden');
+  });
+
+  it('should control visibility property with Hide Approach "visibility"', () => {
+    const node = debugElementOne.nativeElement.querySelector('#some-div');
+    expect(node.style.visibility).toBe('hidden');
+  });
+
+  it('should control hidden HTML property with Hide Approach "hidden"', () => {
+    const node = debugElementThree.nativeElement.querySelector('#some-div-3');
+    expect(node.hidden).toBe(true);
   });
 });

--- a/projects/ng-can/src/lib/directives/can.directive.ts
+++ b/projects/ng-can/src/lib/directives/can.directive.ts
@@ -1,6 +1,6 @@
 import { Directive, ElementRef, Inject, Input, OnInit } from '@angular/core';
 import { NgCanService } from '../services/ng-can.service';
-import { IModuleOptions, INgCanPermissions } from '../ng-can.typings';
+import { IModuleOptions, INgCanPermissions, THideApproach } from '../ng-can.typings';
 import { MODULE_OPTIONS } from '../module.options';
 
 @Directive({
@@ -10,13 +10,15 @@ export class NgCanDirective implements OnInit {
   @Input() conditions: INgCanPermissions = {};
   @Input() permissions: INgCanPermissions = {};
   @Input() strictMode: boolean;
+  @Input() hideApproach: THideApproach = this.options.hide_approach;
 
   constructor(protected el: ElementRef, protected ngCanService: NgCanService,
               @Inject(MODULE_OPTIONS) protected options: IModuleOptions) {
-    this.hideElement();
   }
 
   ngOnInit(): void {
+    this.hideElement();
+
     this.ngCanService.loadPermissions(this.permissions);
     const needToShow = this.ngCanService.checkConditions(this.conditions, this.strictMode);
 
@@ -26,10 +28,10 @@ export class NgCanDirective implements OnInit {
   }
 
   hideElement() {
-    this.el.nativeElement.style.visibility = 'hidden';
+    this.ngCanService.hideElement(this.el, this.hideApproach);
   }
 
   showElement() {
-    this.el.nativeElement.style.visibility = 'visible';
+    this.ngCanService.showElement(this.el, this.hideApproach);
   }
 }

--- a/projects/ng-can/src/lib/ng-can.typings.ts
+++ b/projects/ng-can/src/lib/ng-can.typings.ts
@@ -1,14 +1,23 @@
+import { ElementRef } from '@angular/core';
+
 export interface INgCanPermissionsCheckable {
   loadPermissions(permissions: INgCanPermissions): void;
 
   checkConditions(conditions: INgCanPermissions, strict?: boolean): boolean;
 }
 
+export interface INgCanHideApproachesControllable {
+  hideElement(el: ElementRef, hideApproach: THideApproach): void;
+
+  showElement(el: ElementRef, hideApproach: THideApproach): void;
+}
+
+
 export interface INgCanPermissions {
   [key: string]: boolean;
 }
 
-export type THideApproach = 'visibility';
+export type THideApproach = 'visibility' | 'hidden';
 
 export interface IModuleOptions {
   hide_approach: THideApproach;

--- a/projects/ng-can/src/lib/services/ng-can.service.ts
+++ b/projects/ng-can/src/lib/services/ng-can.service.ts
@@ -1,10 +1,15 @@
-import { Injectable } from '@angular/core';
-import { INgCanPermissions, INgCanPermissionsCheckable } from '../ng-can.typings';
+import { ElementRef, Injectable } from '@angular/core';
+import {
+  INgCanPermissions,
+  INgCanPermissionsCheckable,
+  INgCanHideApproachesControllable,
+  THideApproach
+} from '../ng-can.typings';
 
 @Injectable({
   providedIn: 'root'
 })
-export class NgCanService implements INgCanPermissionsCheckable {
+export class NgCanService implements INgCanPermissionsCheckable, INgCanHideApproachesControllable {
   private _permissions: INgCanPermissions = {};
 
   constructor() {
@@ -39,5 +44,43 @@ export class NgCanService implements INgCanPermissionsCheckable {
     }
 
     return allowed;
+  }
+
+  hideElement(el: ElementRef, hideApproach: THideApproach): void {
+    switch (hideApproach) {
+      case 'visibility': {
+        el.nativeElement.style.visibility = 'hidden';
+
+        break;
+      }
+
+      case 'hidden': {
+        el.nativeElement.hidden = true;
+
+        break;
+      }
+
+      default:
+        throw new Error(`Unknown Hide Approach ${hideApproach}`);
+    }
+  }
+
+  showElement(el: ElementRef, hideApproach: THideApproach): void {
+    switch (hideApproach) {
+      case 'visibility': {
+        el.nativeElement.style.visibility = 'visible';
+
+        break;
+      }
+
+      case 'hidden': {
+        el.nativeElement.hidden = false;
+
+        break;
+      }
+
+      default:
+        throw new Error(`Unknown Hide Approach ${hideApproach}`);
+    }
   }
 }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -8,13 +8,32 @@
 </div>
 <h2>Here are some links to help you start: </h2>
 <ul>
+
   <li ng-can [conditions]="{'can_edit': true}"
       [permissions]="permissions"
+      [hideApproach]="'visibility'"
       [strictMode]="true">
     <h2>
-      <a target="_blank" rel="noopener" href="https://angular.io/tutorial">Tour of Heroes</a>
+      <a target="_blank" rel="noopener" href="https://angular.io/tutorial">Visibility</a>
     </h2>
   </li>
+
+  <li ng-can [conditions]="{'can_edit': true}"
+      [permissions]="permissions"
+      [hideApproach]="'hidden'"
+      [strictMode]="true">
+    <h2>
+      <a target="_blank" rel="noopener" href="https://angular.io/tutorial">Hidden</a>
+    </h2>
+  </li>
+
+  <li ng-can [conditions]="{'can_edit': true}"
+      [permissions]="permissions">
+    <h2>
+      <a target="_blank" rel="noopener" href="https://angular.io/tutorial">Default</a>
+    </h2>
+  </li>
+
   <li>
     <h2><a target="_blank" rel="noopener" href="https://angular.io/cli">CLI Documentation</a></h2>
   </li>


### PR DESCRIPTION
Now, you can pass `hide_approach` param either with .forChild() Module init or with [hideApproach] @Input() Directive property.
Allowed approaches are: 'visibility', 'hidden'.